### PR TITLE
webflux dependency usage

### DIFF
--- a/common-rest-api-utils/pom.xml
+++ b/common-rest-api-utils/pom.xml
@@ -14,4 +14,11 @@
   <artifactId>common-rest-api-utils</artifactId>
   <name>common-rest-api-utils</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/dynamic-delta-billing-service/pom.xml
+++ b/dynamic-delta-billing-service/pom.xml
@@ -12,7 +12,19 @@
   <description>Increases the base pay judging by the weather/traffic conditions</description>
 
   <dependencies>
+    <!-- Common utility classes -->
+    <dependency>
+      <groupId>com.ridesharing</groupId>
+      <artifactId>common-rest-api-utils</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Spring backbone dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-stream</artifactId>
@@ -70,12 +82,6 @@
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.ridesharing</groupId>
-      <artifactId>common-rest-api-utils</artifactId>
-      <version>1.0-SNAPSHOT</version>
-      <scope>compile</scope>
     </dependency>
 
     <!-- Open API -->

--- a/gps-position-tracker-service/pom.xml
+++ b/gps-position-tracker-service/pom.xml
@@ -11,12 +11,18 @@
   <name>gps-position-tracker-service</name>
 
   <dependencies>
-    <!-- Spring backbone dependencies -->
+    <!-- Domain model -->
     <dependency>
       <groupId>com.ridesharing</groupId>
       <artifactId>domain-model</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
+    </dependency>
+
+    <!-- Spring backbone dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -66,7 +72,6 @@
       <artifactId>springdoc-openapi-webflux-ui</artifactId>
       <version>${open.api.version}</version>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/gps-service/pom.xml
+++ b/gps-service/pom.xml
@@ -12,7 +12,19 @@
   <description>Address to GPS translation service</description>
 
   <dependencies>
+    <!-- Common utility classes -->
+    <dependency>
+      <groupId>com.ridesharing</groupId>
+      <artifactId>common-rest-api-utils</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Spring backbone dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
@@ -20,12 +32,6 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.ridesharing</groupId>
-      <artifactId>common-rest-api-utils</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
     </dependency>
 
     <!-- Open API -->

--- a/payment-service/pom.xml
+++ b/payment-service/pom.xml
@@ -15,10 +15,10 @@
   </properties>
 
   <dependencies>
+    <!-- Spring backbone dependencies -->
     <dependency>
-      <groupId>com.stripe</groupId>
-      <artifactId>stripe-java</artifactId>
-      <version>${stripe.api.version}</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
 
     <dependency>
@@ -28,6 +28,13 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+
+    <!-- Stripe SDK -->
+    <dependency>
+      <groupId>com.stripe</groupId>
+      <artifactId>stripe-java</artifactId>
+      <version>${stripe.api.version}</version>
     </dependency>
 
     <!-- Open API -->

--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
-    </dependency>
-
     <!-- Utility dependencies -->
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/ride-planner-service/pom.xml
+++ b/ride-planner-service/pom.xml
@@ -12,7 +12,7 @@
     <name>ride-planner-service</name>
 
     <dependencies>
-        <!-- Spring backbone dependencies -->
+        <!-- Domain model -->
         <dependency>
             <groupId>com.ridesharing</groupId>
             <artifactId>domain-model</artifactId>
@@ -20,6 +20,11 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Spring backbone dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream</artifactId>


### PR DESCRIPTION
Declared the dependency only in the microservices which use the reactive stack. For instance, the innate applications server for the Eureka
server is Tomcat. The simultaneous usage of spring web and spring reactive web should be avoided!

Solves https://github.com/cdinescu/ride-sharing-app/issues/53

Signed-off-by: Cristina Dinescu <crina91@gmail.com>